### PR TITLE
Fix ynh systemd action line match

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -10,8 +10,6 @@ WorkingDirectory=__FINALPATH__/
 ExecStart=/usr/bin/java -jar -Xmx1g app.jar --server.port=__PORT__ --server.servlet.context-path="__PATH__/"
 Restart=on-failure
 RestartSec=10
-StandardOutput=null
-StandardError=syslog
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -108,7 +108,7 @@ fi
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --weight=5
 
-ynh_systemd_action --service_name=$app --action=start --log_path="systemd" --line_match="Started Komga server"
+ynh_systemd_action --service_name=$app --action=start --log_path="systemd" --line_match="Tomcat started on port\(s\): $port \(http\) with context path '$path_url'"
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/install
+++ b/scripts/install
@@ -153,6 +153,8 @@ ynh_systemd_action --service_name=$app --action=start --log_path="systemd" --lin
 #=================================================
 ynh_script_progression --message="Configuring permissions..." --weight=3
 
+ynh_permission_url --permission="main" --auth_header="false"
+
 # Make app public if necessary
 if [ $is_public -eq 1 ]
 then

--- a/scripts/install
+++ b/scripts/install
@@ -146,7 +146,7 @@ yunohost service add $app --description="Media server for your comics, manga and
 ynh_script_progression --message="Starting a systemd service..." --weight=1
 
 # Start a systemd service
-ynh_systemd_action --service_name=$app --action=start --log_path="systemd" --line_match="Started Komga server"
+ynh_systemd_action --service_name=$app --action=start --log_path="systemd" --line_match="Tomcat started on port\(s\): $port \(http\) with context path '$path_url'"
 
 #=================================================
 # SETUP SSOWAT

--- a/scripts/restore
+++ b/scripts/restore
@@ -31,6 +31,7 @@ app=$YNH_APP_INSTANCE_NAME
 domain=$(ynh_app_setting_get --app=$app --key=domain)
 path_url=$(ynh_app_setting_get --app=$app --key=path)
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
+port=$(ynh_app_setting_get --app=$app --key=port)
 
 #=================================================
 # CHECK IF THE APP CAN BE RESTORED
@@ -110,7 +111,7 @@ yunohost service add $app --description="Media server for your comics, manga and
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --weight=3
 
-ynh_systemd_action --service_name=$app --action=start --log_path="systemd" --line_match="Started Komga server"
+ynh_systemd_action --service_name=$app --action=start --log_path="systemd" --line_match="Tomcat started on port\(s\): $port \(http\) with context path '$path_url'"
 
 #=================================================
 # RESTORE THE LOGROTATE CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -132,7 +132,7 @@ yunohost service add $app --description="Media server for your comics, manga and
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --weight=2
 
-ynh_systemd_action --service_name=$app --action=start --log_path="systemd" --line_match="Started Komga server"
+ynh_systemd_action --service_name=$app --action=start --log_path="systemd" --line_match="Tomcat started on port\(s\): $port \(http\) with context path '$path_url'"
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -32,6 +32,8 @@ upgrade_type=$(ynh_check_app_version_changed)
 #=================================================
 ynh_script_progression --message="Ensuring downward compatibility..." --weight=1
 
+ynh_permission_url --permission="main" --auth_header="false"
+
 #=================================================
 # BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
 #=================================================


### PR DESCRIPTION
## Problem
- *`ynh_systemd_action` doesn't work properly if we discard all logs*

## Solution
- *Fix do not discard logs, and fix `line_match` argument*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
* An automatic package_check will be launch at https://ci-apps-dev.yunohost.org/, when you add a specific comment to your Pull Request: "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!"*
