### PR TITLE
disable auth_header

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -153,6 +153,8 @@ ynh_systemd_action --service_name=$app --action=start --log_path="systemd" --lin
 #=================================================
 ynh_script_progression --message="Configuring permissions..." --weight=3
 
+ynh_permission_url --permission="main" --auth_header="false"
+
 # Make app public if necessary
 if [ $is_public -eq 1 ]
 then

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -32,6 +32,8 @@ upgrade_type=$(ynh_check_app_version_changed)
 #=================================================
 ynh_script_progression --message="Ensuring downward compatibility..." --weight=1
 
+ynh_permission_url --permission="main" --auth_header="false"
+
 #=================================================
 # BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
 #=================================================


### PR DESCRIPTION
## Problem
- *We can't access the app with `auth_header` enabled*

## Solution
- *Disable `auth_header`*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
* An automatic package_check will be launch at https://ci-apps-dev.yunohost.org/, when you add a specific comment to your Pull Request: "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!"*
