### PR TITLE
Fix CI Tests Failing

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -146,7 +146,7 @@ yunohost service add $app --description="Media server for your comics, manga and
 ynh_script_progression --message="Starting a systemd service..." --weight=1
 
 # Start a systemd service
-ynh_systemd_action --service_name=$app --action=start --log_path="systemd" --line_match="Tomcat initialized with port\(s\): $port \(http\)" --timeout="500"
+ynh_systemd_action --service_name=$app --action=start --log_path="systemd" --line_match="Tomcat started on port\(s\): $port \(http\) with context path '$path_url'" --timeout="800"
 
 #=================================================
 # SETUP SSOWAT

--- a/scripts/install
+++ b/scripts/install
@@ -146,7 +146,7 @@ yunohost service add $app --description="Media server for your comics, manga and
 ynh_script_progression --message="Starting a systemd service..." --weight=1
 
 # Start a systemd service
-ynh_systemd_action --service_name=$app --action=start --log_path="systemd" --line_match="Tomcat started on port\(s\): $port \(http\) with context path '$path_url'" --timeout="800"
+ynh_systemd_action --service_name=$app --action=start --log_path="systemd" --line_match="Completed initialization" --timeout="800"
 
 #=================================================
 # SETUP SSOWAT

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -130,7 +130,7 @@ yunohost service add $app --description="Media server for your comics, manga and
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --weight=2
 
-ynh_systemd_action --service_name=$app --action=start --log_path="systemd" --line_match="Tomcat initialized with port\(s\): $port \(http\)" --timeout="500"
+ynh_systemd_action --service_name=$app --action=start --log_path="systemd" --line_match="Tomcat started on port\(s\): $port \(http\) with context path '$path_url'" --timeout="800"
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -130,7 +130,7 @@ yunohost service add $app --description="Media server for your comics, manga and
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --weight=2
 
-ynh_systemd_action --service_name=$app --action=start --log_path="systemd" --line_match="Tomcat started on port\(s\): $port \(http\) with context path '$path_url'" --timeout="800"
+ynh_systemd_action --service_name=$app --action=start --log_path="systemd" --line_match="Completed initialization" --timeout="800"
 
 #=================================================
 # RELOAD NGINX


### PR DESCRIPTION
<details open>
<summary>Log from last CI</summary>
<br>

Thu 04 Mar 2021 01:11:30 PM UTC - Starting a test for komga on architecture amd64 with yunohost stable
Testing package https://github.com/YunoHost-Apps/komga_ynh
 on branch testing
 (commit 776503b71e453df6f12236fdf07a30ade4cfb274)
Parsing check_process file
Launching new LXC ynh-appci-buster-amd64-stable-test ...

 > YunoHost versions

yunohost: 
  repo: stable
  version: 4.1.7.3
yunohost-admin: 
  repo: stable
  version: 4.1.4
moulinette: 
  repo: stable
  version: 4.1.4
ssowat: 
  repo: stable
  version: 4.1.3

 ============================================
  [Test 1/8] Package linter
 ============================================


    [YunoHost App Package Linter]

 App packaging documentation - https://yunohost.org/#/packaging_apps
 App package example         - https://github.com/YunoHost/example_ynh
 Official helpers            - https://yunohost.org/#/packaging_apps_helpers_en
 Experimental helpers        - https://github.com/YunoHost-Apps/Experimental_helpers

 If you believe this linter returns false negative (warnings / errors which shouldn't happen),
 please report them on https://github.com/YunoHost/package_linter/issues
    
  Analyzing app /tmp/package_check.nSRcgr/app_folder ...

 ⓘ manifest.json

    - Consider adding an 'help' key for argument 'is_public' to explain to the user what it means for *this* app to be public or private :
    "help": {
       "en": "Some explanation"
    }

 ✔ scripts/_common.sh
 ✔ scripts/install
 ✔ scripts/remove
 ✔ scripts/upgrade
 ✔ scripts/backup
 ✔ scripts/restore
 ! General stuff, misc helper usage

    ! Please add a badge displaying the level of the app in the README.  At least something like :
   [![Integration level](https://dash.yunohost.org/integration/komga.svg)](https://dash.yunohost.org/appci/app/komga)
  (but ideally you should check example_ynh for the full set of recommendations !) 

 ✔ Configuration files
 ✔ Catalog infos
 =======
 Only 1 warning remaining! You can do it!

--- SUCCESS ---

Working time for this test: 3 seconds (13:14:41)

 ============================================
  [Test 2/8] Installation on the root
 ============================================

Running: yunohost app install --force /app_folder -a domain=sub.domain.tld&path=/&is_public=1&port=8080&admin=package_checker&
1294 INFO Installing komga...
1957 INFO [....................] > Validating installation parameters...
2999 INFO [++..................] > Storing installation settings...
3823 INFO [##..................] > Finding an available port...
4356 INFO [##+.................] > Installing dependencies...
28782 WARNING update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
32118 WARNING head: cannot open '/etc/ssl/certs/java/cacerts' for reading: No such file or directory
38742 INFO [###+++++++..........] > Setting up source files...
44208 INFO [##########+.........] > Configuring NGINX web server...
46774 INFO [###########+........] > Configuring system user...
47408 INFO [############+.......] > Configuring a systemd service...
49412 INFO [#############.......] > Configuring log rotation...
49625 INFO [#############+......] > Integrating service in YunoHost...
50654 INFO [##############+.....] > Starting a systemd service...
555580 WARNING Please wait, the service komga is starting..................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
555585 WARNING The service komga didn't fully executed the action start before the timeout.
555587 WARNING Please find here an extract of the end of the log of the service komga:
555741 WARNING Mar 04 13:25:04 java[6932]:         at org.springframework.boot.web.servlet.server.AbstractServletWebServerFactory.checkContextPath(AbstractServletWebServerFactory.java:133) ~[spring-boot-2.4.1.jar!/:2.4.1]
555742 WARNING Mar 04 13:25:04 java[6932]:         at org.springframework.boot.web.servlet.server.AbstractServletWebServerFactory.setContextPath(AbstractServletWebServerFactory.java:125) ~[spring-boot-2.4.1.jar!/:2.4.1]
555743 WARNING Mar 04 13:25:04 java[6932]:         at org.springframework.boot.context.properties.PropertyMapper$Source.to(PropertyMapper.java:316) ~[spring-boot-2.4.1.jar!/:2.4.1]
555745 WARNING Mar 04 13:25:04 java[6932]:         at org.springframework.boot.autoconfigure.web.servlet.ServletWebServerFactoryCustomizer.customize(ServletWebServerFactoryCustomizer.java:66) ~[spring-boot-autoconfigure-2.4.1.jar!/:2.4.1]
555746 WARNING Mar 04 13:25:04 java[6932]:         at org.springframework.boot.autoconfigure.web.servlet.ServletWebServerFactoryCustomizer.customize(ServletWebServerFactoryCustomizer.java:39) ~[spring-boot-autoconfigure-2.4.1.jar!/:2.4.1]
555747 WARNING Mar 04 13:25:04 java[6932]:         at org.springframework.boot.web.server.WebServerFactoryCustomizerBeanPostProcessor.lambda$postProcessBeforeInitialization$0(WebServerFactoryCustomizerBeanPostProcessor.java:72) ~[spring-boot-2.4.1.jar!/:2.4.1]
555748 WARNING Mar 04 13:25:04 java[6932]:         at org.springframework.boot.util.LambdaSafe$Callbacks.lambda$null$0(LambdaSafe.java:287) ~[spring-boot-2.4.1.jar!/:2.4.1]
555749 WARNING Mar 04 13:25:04 java[6932]:         at org.springframework.boot.util.LambdaSafe$LambdaSafeCallback.invoke(LambdaSafe.java:159) ~[spring-boot-2.4.1.jar!/:2.4.1]
555749 WARNING Mar 04 13:25:04 java[6932]:         at org.springframework.boot.util.LambdaSafe$Callbacks.lambda$invoke$1(LambdaSafe.java:286) ~[spring-boot-2.4.1.jar!/:2.4.1]
555750 WARNING Mar 04 13:25:04 java[6932]:         at java.base/java.util.ArrayList.forEach(ArrayList.java:1541) ~[na:na]
555751 WARNING Mar 04 13:25:04 java[6932]:         at java.base/java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1085) ~[na:na]
555751 WARNING Mar 04 13:25:04 java[6932]:         at org.springframework.boot.util.LambdaSafe$Callbacks.invoke(LambdaSafe.java:286) ~[spring-boot-2.4.1.jar!/:2.4.1]
555752 WARNING Mar 04 13:25:04 java[6932]:         at org.springframework.boot.web.server.WebServerFactoryCustomizerBeanPostProcessor.postProcessBeforeInitialization(WebServerFactoryCustomizerBeanPostProcessor.java:72) ~[spring-boot-2.4.1.jar!/:2.4.1]
555753 WARNING Mar 04 13:25:04 java[6932]:         at org.springframework.boot.web.server.WebServerFactoryCustomizerBeanPostProcessor.postProcessBeforeInitialization(WebServerFactoryCustomizerBeanPostProcessor.java:58) ~[spring-boot-2.4.1.jar!/:2.4.1]
555753 WARNING Mar 04 13:25:04 java[6932]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyBeanPostProcessorsBeforeInitialization(AbstractAutowireCapableBeanFactory.java:429) ~[spring-beans-5.3.2.jar!/:5.3.2]
555754 WARNING Mar 04 13:25:04 java[6932]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1780) ~[spring-beans-5.3.2.jar!/:5.3.2]
555755 WARNING Mar 04 13:25:04 java[6932]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:609) ~[spring-beans-5.3.2.jar!/:5.3.2]
555755 WARNING Mar 04 13:25:04 java[6932]:         ... 25 common frames omitted
555756 WARNING Mar 04 13:25:04 systemd[1]: komga.service: Main process exited, code=exited, status=1/FAILURE
555757 WARNING Mar 04 13:25:04 systemd[1]: komga.service: Failed with result 'exit-code'.
555891 INFO [###############+....] > Configuring permissions...
558256 INFO [################+++.] > Reloading NGINX web server...
559076 SUCCESS Installation completed

 > Validating that the app can (or cannot) be accessed with its url...

Error: The HTTP code shows an error.
Warning: Test url: sub.domain.tld
Real url: https://sub.domain.tld/
HTTP code: 502
Page title: 
Page extract:
                               502 Bad Gateway
     __________________________________________________________________

                                    nginx
Error: The HTTP code shows an error.
Warning: Test url: sub.domain.tld/
Real url: https://sub.domain.tld/
HTTP code: 502
Page title: 
Page extract:
                               502 Bad Gateway
     __________________________________________________________________

                                    nginx

--- FAIL ---

Working time for this test: 10 minutes, 40 seconds (13:25:26)

 ============================================
  [Test 3/8] Installation in a sub path
 ============================================

Running: yunohost app install --force /app_folder -a domain=sub.domain.tld&path=/path&is_public=1&port=8080&admin=package_checker&
1241 INFO Installing komga...
1869 INFO [....................] > Validating installation parameters...
2883 INFO [++..................] > Storing installation settings...
3736 INFO [##..................] > Finding an available port...
4290 INFO [##+.................] > Installing dependencies...
37549 WARNING update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
40575 WARNING head: cannot open '/etc/ssl/certs/java/cacerts' for reading: No such file or directory
46804 INFO [###+++++++..........] > Setting up source files...
52804 INFO [##########+.........] > Configuring NGINX web server...
55169 INFO [###########+........] > Configuring system user...
55692 INFO [############+.......] > Configuring a systemd service...
57567 INFO [#############.......] > Configuring log rotation...
57673 INFO [#############+......] > Integrating service in YunoHost...
58594 INFO [##############+.....] > Starting a systemd service...
70839 WARNING Please wait, the service komga is starting..........
70947 INFO The service komga has correctly executed the action start.
71371 INFO [###############+....] > Configuring permissions...
73806 INFO [################+++.] > Reloading NGINX web server...
74213 INFO [####################] > Installation of komga completed
75012 SUCCESS Installation completed

 > Validating that the app can (or cannot) be accessed with its url...

Error: The HTTP code shows an error.
Warning: Test url: sub.domain.tld/path
Real url: https://sub.domain.tld/path/
HTTP code: 502
Page title: 
Page extract:
                               502 Bad Gateway
     __________________________________________________________________

                                    nginx
Error: The HTTP code shows an error.
Warning: Test url: sub.domain.tld/path/
Real url: https://sub.domain.tld/path/
HTTP code: 502
Page title: 
Page extract:
                               502 Bad Gateway
     __________________________________________________________________

                                    nginx

--- FAIL ---

Working time for this test: 2 minutes, 33 seconds (13:28:04)

 ============================================
  [Test 4/8] Installation in private mode
 ============================================

Running: yunohost app install --force /app_folder -a domain=sub.domain.tld&path=/&is_public=0&port=8080&admin=package_checker&
1273 INFO Installing komga...
1959 INFO [....................] > Validating installation parameters...
2768 INFO [++..................] > Storing installation settings...
3510 INFO [##..................] > Finding an available port...
5074 INFO [##+.................] > Installing dependencies...
35019 WARNING update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
38149 WARNING head: cannot open '/etc/ssl/certs/java/cacerts' for reading: No such file or directory
44719 INFO [###+++++++..........] > Setting up source files...
54128 INFO [##########+.........] > Configuring NGINX web server...
56670 INFO [###########+........] > Configuring system user...
57187 INFO [############+.......] > Configuring a systemd service...
59179 INFO [#############.......] > Configuring log rotation...
59190 INFO [#############+......] > Integrating service in YunoHost...
59801 INFO [##############+.....] > Starting a systemd service...
564461 WARNING Please wait, the service komga is starting..................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
564571 WARNING The service komga didn't fully executed the action start before the timeout.
564573 WARNING Please find here an extract of the end of the log of the service komga:
564624 WARNING Mar 04 13:38:32 java[6929]:         at org.springframework.boot.autoconfigure.web.servlet.ServletWebServerFactoryCustomizer.customize(ServletWebServerFactoryCustomizer.java:39) ~[spring-boot-autoconfigure-2.4.1.jar!/:2.4.1]
564627 WARNING Mar 04 13:38:32 java[6929]:         at org.springframework.boot.web.server.WebServerFactoryCustomizerBeanPostProcessor.lambda$postProcessBeforeInitialization$0(WebServerFactoryCustomizerBeanPostProcessor.java:72) ~[spring-boot-2.4.1.jar!/:2.4.1]
564628 WARNING Mar 04 13:38:32 java[6929]:         at org.springframework.boot.util.LambdaSafe$Callbacks.lambda$null$0(LambdaSafe.java:287) ~[spring-boot-2.4.1.jar!/:2.4.1]
564629 WARNING Mar 04 13:38:32 java[6929]:         at org.springframework.boot.util.LambdaSafe$LambdaSafeCallback.invoke(LambdaSafe.java:159) ~[spring-boot-2.4.1.jar!/:2.4.1]
564630 WARNING Mar 04 13:38:32 java[6929]:         at org.springframework.boot.util.LambdaSafe$Callbacks.lambda$invoke$1(LambdaSafe.java:286) ~[spring-boot-2.4.1.jar!/:2.4.1]
564631 WARNING Mar 04 13:38:32 java[6929]:         at java.base/java.util.ArrayList.forEach(ArrayList.java:1541) ~[na:na]
564632 WARNING Mar 04 13:38:32 java[6929]:         at java.base/java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1085) ~[na:na]
564634 WARNING Mar 04 13:38:32 java[6929]:         at org.springframework.boot.util.LambdaSafe$Callbacks.invoke(LambdaSafe.java:286) ~[spring-boot-2.4.1.jar!/:2.4.1]
564636 WARNING Mar 04 13:38:32 java[6929]:         at org.springframework.boot.web.server.WebServerFactoryCustomizerBeanPostProcessor.postProcessBeforeInitialization(WebServerFactoryCustomizerBeanPostProcessor.java:72) ~[spring-boot-2.4.1.jar!/:2.4.1]
564637 WARNING Mar 04 13:38:32 java[6929]:         at org.springframework.boot.web.server.WebServerFactoryCustomizerBeanPostProcessor.postProcessBeforeInitialization(WebServerFactoryCustomizerBeanPostProcessor.java:58) ~[spring-boot-2.4.1.jar!/:2.4.1]
564638 WARNING Mar 04 13:38:32 java[6929]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyBeanPostProcessorsBeforeInitialization(AbstractAutowireCapableBeanFactory.java:429) ~[spring-beans-5.3.2.jar!/:5.3.2]
564639 WARNING Mar 04 13:38:32 java[6929]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1780) ~[spring-beans-5.3.2.jar!/:5.3.2]
564639 WARNING Mar 04 13:38:32 java[6929]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:609) ~[spring-beans-5.3.2.jar!/:5.3.2]
564649 WARNING Mar 04 13:38:32 java[6929]:         ... 25 common frames omitted
564652 WARNING Mar 04 13:38:32 systemd[1]: komga.service: Main process exited, code=exited, status=1/FAILURE
564656 WARNING Mar 04 13:38:32 systemd[1]: komga.service: Failed with result 'exit-code'.
564658 WARNING Mar 04 13:38:42 systemd[1]: komga.service: Service RestartSec=10s expired, scheduling restart.
564660 WARNING Mar 04 13:38:42 systemd[1]: komga.service: Scheduled restart job, restart counter is at 24.
564664 WARNING Mar 04 13:38:42 systemd[1]: Stopped Komga server.
564665 WARNING Mar 04 13:38:42 systemd[1]: Started Komga server.
565009 INFO [###############+....] > Configuring permissions...
566445 INFO [################+++.] > Reloading NGINX web server...
567406 SUCCESS Installation completed

 > Validating that the app can (or cannot) be accessed with its url...


 > Removing the app...

268  INFO Removing komga...
775  INFO [+...................] > Loading installation settings...
2463 INFO [#+..................] > Removing komga service integration...
2908 INFO [##+++...............] > Stopping and removing the systemd service...
5850 INFO [#####+..............] > Removing dependencies...
17159 INFO [######+++++++.......] > Removing app main directory and database...
17387 INFO [#############++.....] > Removing NGINX web server configuration...
17822 INFO [###############++...] > Removing logrotate configuration...
18064 INFO [#################+..] > Removing the dedicated system user...
18484 INFO [####################] > Removal of komga completed
18521 SUCCESS komga removed

 > Reinstalling after removal.

Running: yunohost app install --force /app_folder -a domain=sub.domain.tld&path=/&is_public=0&port=8080&admin=package_checker&
1075 INFO Installing komga...
1658 INFO [....................] > Validating installation parameters...
2600 INFO [++..................] > Storing installation settings...
3335 INFO [##..................] > Finding an available port...
4976 INFO [##+.................] > Installing dependencies...
28888 WARNING update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
32016 WARNING head: cannot open '/etc/ssl/certs/java/cacerts' for reading: No such file or directory
38153 INFO [###+++++++..........] > Setting up source files...
42366 INFO [##########+.........] > Configuring NGINX web server...
44755 INFO [###########+........] > Configuring system user...
45081 INFO [############+.......] > Configuring a systemd service...
46925 INFO [#############.......] > Configuring log rotation...
47333 INFO [#############+......] > Integrating service in YunoHost...
47548 INFO [##############+.....] > Starting a systemd service...
552413 WARNING Please wait, the service komga is starting..................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
552416 WARNING The service komga didn't fully executed the action start before the timeout.
552418 WARNING Please find here an extract of the end of the log of the service komga:
552536 WARNING Mar 04 13:48:36 java[15662]:         at org.springframework.boot.autoconfigure.web.servlet.ServletWebServerFactoryCustomizer.customize(ServletWebServerFactoryCustomizer.java:39) ~[spring-boot-autoconfigure-2.4.1.jar!/:2.4.1]
552538 WARNING Mar 04 13:48:36 java[15662]:         at org.springframework.boot.web.server.WebServerFactoryCustomizerBeanPostProcessor.lambda$postProcessBeforeInitialization$0(WebServerFactoryCustomizerBeanPostProcessor.java:72) ~[spring-boot-2.4.1.jar!/:2.4.1]
552539 WARNING Mar 04 13:48:36 java[15662]:         at org.springframework.boot.util.LambdaSafe$Callbacks.lambda$null$0(LambdaSafe.java:287) ~[spring-boot-2.4.1.jar!/:2.4.1]
552540 WARNING Mar 04 13:48:36 java[15662]:         at org.springframework.boot.util.LambdaSafe$LambdaSafeCallback.invoke(LambdaSafe.java:159) ~[spring-boot-2.4.1.jar!/:2.4.1]
552542 WARNING Mar 04 13:48:36 java[15662]:         at org.springframework.boot.util.LambdaSafe$Callbacks.lambda$invoke$1(LambdaSafe.java:286) ~[spring-boot-2.4.1.jar!/:2.4.1]
552544 WARNING Mar 04 13:48:36 java[15662]:         at java.base/java.util.ArrayList.forEach(ArrayList.java:1541) ~[na:na]
552545 WARNING Mar 04 13:48:36 java[15662]:         at java.base/java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1085) ~[na:na]
552546 WARNING Mar 04 13:48:36 java[15662]:         at org.springframework.boot.util.LambdaSafe$Callbacks.invoke(LambdaSafe.java:286) ~[spring-boot-2.4.1.jar!/:2.4.1]
552552 WARNING Mar 04 13:48:36 java[15662]:         at org.springframework.boot.web.server.WebServerFactoryCustomizerBeanPostProcessor.postProcessBeforeInitialization(WebServerFactoryCustomizerBeanPostProcessor.java:72) ~[spring-boot-2.4.1.jar!/:2.4.1]
552553 WARNING Mar 04 13:48:36 java[15662]:         at org.springframework.boot.web.server.WebServerFactoryCustomizerBeanPostProcessor.postProcessBeforeInitialization(WebServerFactoryCustomizerBeanPostProcessor.java:58) ~[spring-boot-2.4.1.jar!/:2.4.1]
552554 WARNING Mar 04 13:48:36 java[15662]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyBeanPostProcessorsBeforeInitialization(AbstractAutowireCapableBeanFactory.java:429) ~[spring-beans-5.3.2.jar!/:5.3.2]
552555 WARNING Mar 04 13:48:36 java[15662]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1780) ~[spring-beans-5.3.2.jar!/:5.3.2]
552557 WARNING Mar 04 13:48:36 java[15662]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:609) ~[spring-beans-5.3.2.jar!/:5.3.2]
552558 WARNING Mar 04 13:48:36 java[15662]:         ... 25 common frames omitted
552559 WARNING Mar 04 13:48:36 systemd[1]: komga.service: Main process exited, code=exited, status=1/FAILURE
552560 WARNING Mar 04 13:48:36 systemd[1]: komga.service: Failed with result 'exit-code'.
552560 WARNING Mar 04 13:48:46 systemd[1]: komga.service: Service RestartSec=10s expired, scheduling restart.
552561 WARNING Mar 04 13:48:46 systemd[1]: komga.service: Scheduled restart job, restart counter is at 24.
552562 WARNING Mar 04 13:48:46 systemd[1]: Stopped Komga server.
552563 WARNING Mar 04 13:48:46 systemd[1]: Started Komga server.
553163 INFO [###############+....] > Configuring permissions...
554513 INFO [################+++.] > Reloading NGINX web server...
555531 SUCCESS Installation completed

 > Validating that the app can (or cannot) be accessed with its url...


--- SUCCESS ---

Working time for this test: 20 minutes, 45 seconds (13:48:57)

 ============================================
  [Test 5/8] Multi-instance installations
 ============================================


 > First installation: path=sub.domain.tld/

Warning: Expected to find an existing snapshot snap_rootinstall but it doesn't exist yet .. will attempt to create it
Running: yunohost app install --force /app_folder -a domain=sub.domain.tld&path=/&is_public=1&port=8080&admin=package_checker&
1049 INFO Installing komga...
1662 INFO [....................] > Validating installation parameters...
2684 INFO [++..................] > Storing installation settings...
3407 INFO [##..................] > Finding an available port...
3860 INFO [##+.................] > Installing dependencies...
25145 WARNING update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
28070 WARNING head: cannot open '/etc/ssl/certs/java/cacerts' for reading: No such file or directory
34096 INFO [###+++++++..........] > Setting up source files...
40282 INFO [##########+.........] > Configuring NGINX web server...
42437 INFO [###########+........] > Configuring system user...
42859 INFO [############+.......] > Configuring a systemd service...
44792 INFO [#############.......] > Configuring log rotation...
45105 INFO [#############+......] > Integrating service in YunoHost...
45716 INFO [##############+.....] > Starting a systemd service...
550069 WARNING Please wait, the service komga is starting..................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
550075 WARNING The service komga didn't fully executed the action start before the timeout.
550077 WARNING Please find here an extract of the end of the log of the service komga:
550194 WARNING Mar 04 13:59:46 java[6964]:         at org.springframework.boot.web.server.WebServerFactoryCustomizerBeanPostProcessor.postProcessBeforeInitialization(WebServerFactoryCustomizerBeanPostProcessor.java:58) ~[spring-boot-2.4.1.jar!/:2.4.1]
550201 WARNING Mar 04 13:59:46 java[6964]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyBeanPostProcessorsBeforeInitialization(AbstractAutowireCapableBeanFactory.java:429) ~[spring-beans-5.3.2.jar!/:5.3.2]
550204 WARNING Mar 04 13:59:46 java[6964]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1780) ~[spring-beans-5.3.2.jar!/:5.3.2]
550205 WARNING Mar 04 13:59:46 java[6964]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:609) ~[spring-beans-5.3.2.jar!/:5.3.2]
550207 WARNING Mar 04 13:59:46 java[6964]:         ... 25 common frames omitted
550210 WARNING Mar 04 13:59:46 systemd[1]: komga.service: Main process exited, code=exited, status=1/FAILURE
550211 WARNING Mar 04 13:59:46 systemd[1]: komga.service: Failed with result 'exit-code'.
550212 WARNING Mar 04 13:59:57 systemd[1]: komga.service: Service RestartSec=10s expired, scheduling restart.
550213 WARNING Mar 04 13:59:57 systemd[1]: komga.service: Scheduled restart job, restart counter is at 24.
550214 WARNING Mar 04 13:59:57 systemd[1]: Stopped Komga server.
550215 WARNING Mar 04 13:59:57 systemd[1]: Started Komga server.
550216 WARNING Mar 04 13:59:59 java[7021]:  ____  __.
550217 WARNING Mar 04 13:59:59 java[7021]: |    |/ _|____   _____    _________
550223 WARNING Mar 04 13:59:59 java[7021]: |      < /  _ \ /     \  / ___\__  \
550224 WARNING Mar 04 13:59:59 java[7021]: |    |  (  <_> )  Y Y  \/ /_/  > __ \_
550227 WARNING Mar 04 13:59:59 java[7021]: |____|__ \____/|__|_|  /\___  (____  /
550228 WARNING Mar 04 13:59:59 java[7021]:         \/           \//_____/     \/
550229 WARNING Mar 04 13:59:59 java[7021]: Version: 0.75.1
550230 WARNING Mar 04 13:59:59 java[7021]: 2021-03-04 13:59:59.940  INFO 7021 --- [           main] org.gotson.komga.ApplicationKt           : Starting ApplicationKt using Java 11.0.9.1 on ynh-appci-buster-amd64-stable-test with PID 7021 (/opt/yunohost/komga/app.jar started by komga in /opt/yunohost/komga)
550237 WARNING Mar 04 13:59:59 java[7021]: 2021-03-04 13:59:59.949  INFO 7021 --- [           main] org.gotson.komga.ApplicationKt           : No active profile set, falling back to default profiles: default
550691 INFO [###############+....] > Configuring permissions...
553873 INFO [################+++.] > Reloading NGINX web server...
555121 SUCCESS Installation completed
(Creating snapshot snap_rootinstall ...)

 > Second installation: path=domain.tld/

Running: yunohost app install --force /app_folder -a domain=domain.tld&path=/&is_public=1&port=8080&admin=package_checker&
1350 INFO Installing komga...
2158 INFO [....................] > Validating installation parameters...
3805 INFO [++..................] > Storing installation settings...
4530 INFO [##..................] > Finding an available port...
5054 INFO [##+.................] > Installing dependencies...
16414 INFO [###+++++++..........] > Setting up source files...
21727 INFO [##########+.........] > Configuring NGINX web server...
24863 INFO [###########+........] > Configuring system user...
25486 INFO [############+.......] > Configuring a systemd service...
27811 INFO [#############.......] > Configuring log rotation...
28219 INFO [#############+......] > Integrating service in YunoHost...
28528 INFO [##############+.....] > Starting a systemd service...
534829 WARNING Please wait, the service komga__2 is starting..................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
534831 WARNING The service komga__2 didn't fully executed the action start before the timeout.
534975 WARNING Please find here an extract of the end of the log of the service komga__2:
535048 WARNING Mar 04 14:10:10 java[5511]:         at org.springframework.boot.autoconfigure.web.servlet.ServletWebServerFactoryCustomizer.customize(ServletWebServerFactoryCustomizer.java:39) ~[spring-boot-autoconfigure-2.4.1.jar!/:2.4.1]
535055 WARNING Mar 04 14:10:10 java[5511]:         at org.springframework.boot.web.server.WebServerFactoryCustomizerBeanPostProcessor.lambda$postProcessBeforeInitialization$0(WebServerFactoryCustomizerBeanPostProcessor.java:72) ~[spring-boot-2.4.1.jar!/:2.4.1]
535063 WARNING Mar 04 14:10:10 java[5511]:         at org.springframework.boot.util.LambdaSafe$Callbacks.lambda$null$0(LambdaSafe.java:287) ~[spring-boot-2.4.1.jar!/:2.4.1]
535067 WARNING Mar 04 14:10:10 java[5511]:         at org.springframework.boot.util.LambdaSafe$LambdaSafeCallback.invoke(LambdaSafe.java:159) ~[spring-boot-2.4.1.jar!/:2.4.1]
535071 WARNING Mar 04 14:10:10 java[5511]:         at org.springframework.boot.util.LambdaSafe$Callbacks.lambda$invoke$1(LambdaSafe.java:286) ~[spring-boot-2.4.1.jar!/:2.4.1]
535076 WARNING Mar 04 14:10:10 java[5511]:         at java.base/java.util.ArrayList.forEach(ArrayList.java:1541) ~[na:na]
535078 WARNING Mar 04 14:10:10 java[5511]:         at java.base/java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1085) ~[na:na]
535089 WARNING Mar 04 14:10:10 java[5511]:         at org.springframework.boot.util.LambdaSafe$Callbacks.invoke(LambdaSafe.java:286) ~[spring-boot-2.4.1.jar!/:2.4.1]
535112 WARNING Mar 04 14:10:10 java[5511]:         at org.springframework.boot.web.server.WebServerFactoryCustomizerBeanPostProcessor.postProcessBeforeInitialization(WebServerFactoryCustomizerBeanPostProcessor.java:72) ~[spring-boot-2.4.1.jar!/:2.4.1]
535114 WARNING Mar 04 14:10:10 java[5511]:         at org.springframework.boot.web.server.WebServerFactoryCustomizerBeanPostProcessor.postProcessBeforeInitialization(WebServerFactoryCustomizerBeanPostProcessor.java:58) ~[spring-boot-2.4.1.jar!/:2.4.1]
535118 WARNING Mar 04 14:10:10 java[5511]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyBeanPostProcessorsBeforeInitialization(AbstractAutowireCapableBeanFactory.java:429) ~[spring-beans-5.3.2.jar!/:5.3.2]
535121 WARNING Mar 04 14:10:10 java[5511]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1780) ~[spring-beans-5.3.2.jar!/:5.3.2]
535126 WARNING Mar 04 14:10:10 java[5511]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:609) ~[spring-beans-5.3.2.jar!/:5.3.2]
535132 WARNING Mar 04 14:10:10 java[5511]:         ... 25 common frames omitted
535134 WARNING Mar 04 14:10:10 systemd[1]: komga__2.service: Main process exited, code=exited, status=1/FAILURE
535136 WARNING Mar 04 14:10:10 systemd[1]: komga__2.service: Failed with result 'exit-code'.
535138 WARNING Mar 04 14:10:20 systemd[1]: komga__2.service: Service RestartSec=10s expired, scheduling restart.
535148 WARNING Mar 04 14:10:20 systemd[1]: komga__2.service: Scheduled restart job, restart counter is at 23.
535149 WARNING Mar 04 14:10:20 systemd[1]: Stopped Komga server.
535150 WARNING Mar 04 14:10:20 systemd[1]: Started Komga server.
535567 INFO [###############+....] > Configuring permissions...
538124 INFO [################+++.] > Reloading NGINX web server...
538546 INFO [####################] > Installation of komga__2 completed
539303 SUCCESS Installation completed

 > Validating that the app can (or cannot) be accessed with its url...

Error: The HTTP code shows an error.
Warning: Test url: sub.domain.tld
Real url: https://sub.domain.tld/
HTTP code: 502
Page title: 
Page extract:
                               502 Bad Gateway
     __________________________________________________________________

                                    nginx
Error: The HTTP code shows an error.
Warning: Test url: sub.domain.tld/
Real url: https://sub.domain.tld/
HTTP code: 502
Page title: 
Page extract:
                               502 Bad Gateway
     __________________________________________________________________

                                    nginx

--- FAIL ---

Working time for this test: 21 minutes, 33 seconds (14:10:35)

 ============================================
  [Test 6/8] Backup/Restore
 ============================================

(Reusing existing snapshot snap_rootinstall)

 > Backup of the application...

428  INFO Collecting files to be backed up for komga...
708  INFO Loading installation settings...
1332 INFO Declaring files to be backed up...
3484 INFO Creating a backup archive from the collected files...
4080 SUCCESS Backup created

 > Removing the app...

368  INFO Removing komga...
1172 INFO [+...................] > Loading installation settings...
2913 INFO [#+..................] > Removing komga service integration...
3441 INFO [##+++...............] > Stopping and removing the systemd service...
11804 INFO [#####+..............] > Removing dependencies...
22310 INFO [######+++++++.......] > Removing app main directory and database...
22559 INFO [#############++.....] > Removing NGINX web server configuration...
23205 INFO [###############++...] > Removing logrotate configuration...
23212 INFO [#################+..] > Removing the dedicated system user...
23667 SUCCESS komga removed

 > Restore after removing the application...

243  INFO Preparing archive for restoration...
696  INFO Restoring komga...
1681 INFO [....................] > Loading installation settings...
2827 INFO [+...................] > Validating restoration parameters...
3579 INFO [#++.................] > Restoring the app main directory...
3805 INFO [###+++++............] > Restoring the app database...
4036 INFO [########+...........] > Recreating the dedicated system user...
4470 INFO [#########+..........] > Reinstalling dependencies...
23715 WARNING update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
26751 WARNING head: cannot open '/etc/ssl/certs/java/cacerts' for reading: No such file or directory
32416 INFO [##########++++......] > Restoring the systemd configuration...
32832 INFO [##############++....] > Integrating service in YunoHost...
33565 INFO [################++..] > Starting a systemd service...
336255 WARNING Please wait, the service komga is starting..........................................................................................................................................................................................................................................................................................................
336260 WARNING The service komga didn't fully executed the action start before the timeout.
336263 WARNING Please find here an extract of the end of the log of the service komga:
336421 WARNING Mar 04 14:17:55 java[7604]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1780) ~[spring-beans-5.3.2.jar!/:5.3.2]
336427 WARNING Mar 04 14:17:55 java[7604]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:609) ~[spring-beans-5.3.2.jar!/:5.3.2]
336431 WARNING Mar 04 14:17:55 java[7604]:         ... 25 common frames omitted
336432 WARNING Mar 04 14:17:55 systemd[1]: komga.service: Main process exited, code=exited, status=1/FAILURE
336438 WARNING Mar 04 14:17:55 systemd[1]: komga.service: Failed with result 'exit-code'.
336440 WARNING Mar 04 14:18:05 systemd[1]: komga.service: Service RestartSec=10s expired, scheduling restart.
336443 WARNING Mar 04 14:18:05 systemd[1]: komga.service: Scheduled restart job, restart counter is at 14.
336444 WARNING Mar 04 14:18:05 systemd[1]: Stopped Komga server.
336445 WARNING Mar 04 14:18:05 systemd[1]: Started Komga server.
336446 WARNING Mar 04 14:18:08 java[7659]:  ____  __.
336447 WARNING Mar 04 14:18:08 java[7659]: |    |/ _|____   _____    _________
336448 WARNING Mar 04 14:18:08 java[7659]: |      < /  _ \ /     \  / ___\__  \
336449 WARNING Mar 04 14:18:08 java[7659]: |    |  (  <_> )  Y Y  \/ /_/  > __ \_
336450 WARNING Mar 04 14:18:08 java[7659]: |____|__ \____/|__|_|  /\___  (____  /
336457 WARNING Mar 04 14:18:08 java[7659]:         \/           \//_____/     \/
336461 WARNING Mar 04 14:18:08 java[7659]: Version: 0.75.1
336463 WARNING Mar 04 14:18:08 java[7659]: 2021-03-04 14:18:08.454  INFO 7659 --- [           main] org.gotson.komga.ApplicationKt           : Starting ApplicationKt using Java 11.0.9.1 on ynh-appci-buster-amd64-stable-test with PID 7659 (/opt/yunohost/komga/app.jar started by komga in /opt/yunohost/komga)
336466 WARNING Mar 04 14:18:08 java[7659]: 2021-03-04 14:18:08.463  INFO 7659 --- [           main] org.gotson.komga.ApplicationKt           : No active profile set, falling back to default profiles: default
336469 WARNING Mar 04 14:18:13 java[7659]: 2021-03-04 14:18:13.981  INFO 7659 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data JDBC repositories in DEFAULT mode.
336471 WARNING Mar 04 14:18:14 java[7659]: 2021-03-04 14:18:14.127  INFO 7659 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 136 ms. Found 0 JDBC repository interfaces.
337107 INFO [##################+.] > Reloading NGINX web server...
337667 SUCCESS Restoration completed

 > Validating that the app can (or cannot) be accessed with its url...

Error: The HTTP code shows an error.
Warning: Test url: sub.domain.tld
Real url: https://sub.domain.tld/
HTTP code: 502
Page title: 
Page extract:
                               502 Bad Gateway
     __________________________________________________________________

                                    nginx
Error: The HTTP code shows an error.
Warning: Test url: sub.domain.tld/
Real url: https://sub.domain.tld/
HTTP code: 502
Page title: 
Page extract:
                               502 Bad Gateway
     __________________________________________________________________

                                    nginx

 > Restore on a fresh YunoHost system...

375  INFO Preparing archive for restoration...
682  INFO Restoring komga...
1580 INFO [....................] > Loading installation settings...
2641 INFO [+...................] > Validating restoration parameters...
3477 INFO [#++.................] > Restoring the app main directory...
3693 INFO [###+++++............] > Restoring the app database...
3919 INFO [########+...........] > Recreating the dedicated system user...
4255 INFO [#########+..........] > Reinstalling dependencies...
24585 WARNING update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
27017 WARNING head: cannot open '/etc/ssl/certs/java/cacerts' for reading: No such file or directory
32832 INFO [##########++++......] > Restoring the systemd configuration...
33651 INFO [##############++....] > Integrating service in YunoHost...
33855 INFO [################++..] > Starting a systemd service...
336712 WARNING Please wait, the service komga is starting..........................................................................................................................................................................................................................................................................................................
336716 WARNING The service komga didn't fully executed the action start before the timeout.
336718 WARNING Please find here an extract of the end of the log of the service komga:
336771 WARNING Mar 04 14:24:37 java[5033]:         at org.springframework.boot.web.server.WebServerFactoryCustomizerBeanPostProcessor.postProcessBeforeInitialization(WebServerFactoryCustomizerBeanPostProcessor.java:58) ~[spring-boot-2.4.1.jar!/:2.4.1]
336775 WARNING Mar 04 14:24:37 java[5033]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyBeanPostProcessorsBeforeInitialization(AbstractAutowireCapableBeanFactory.java:429) ~[spring-beans-5.3.2.jar!/:5.3.2]
336777 WARNING Mar 04 14:24:37 java[5033]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1780) ~[spring-beans-5.3.2.jar!/:5.3.2]
336778 WARNING Mar 04 14:24:37 java[5033]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:609) ~[spring-beans-5.3.2.jar!/:5.3.2]
336779 WARNING Mar 04 14:24:37 java[5033]:         ... 25 common frames omitted
336781 WARNING Mar 04 14:24:37 systemd[1]: komga.service: Main process exited, code=exited, status=1/FAILURE
336782 WARNING Mar 04 14:24:37 systemd[1]: komga.service: Failed with result 'exit-code'.
336783 WARNING Mar 04 14:24:47 systemd[1]: komga.service: Service RestartSec=10s expired, scheduling restart.
336785 WARNING Mar 04 14:24:47 systemd[1]: komga.service: Scheduled restart job, restart counter is at 14.
336786 WARNING Mar 04 14:24:47 systemd[1]: Stopped Komga server.
336793 WARNING Mar 04 14:24:47 systemd[1]: Started Komga server.
336794 WARNING Mar 04 14:24:50 java[5086]:  ____  __.
336796 WARNING Mar 04 14:24:50 java[5086]: |    |/ _|____   _____    _________
336798 WARNING Mar 04 14:24:50 java[5086]: |      < /  _ \ /     \  / ___\__  \
336801 WARNING Mar 04 14:24:50 java[5086]: |    |  (  <_> )  Y Y  \/ /_/  > __ \_
336803 WARNING Mar 04 14:24:50 java[5086]: |____|__ \____/|__|_|  /\___  (____  /
336805 WARNING Mar 04 14:24:50 java[5086]:         \/           \//_____/     \/
336807 WARNING Mar 04 14:24:50 java[5086]: Version: 0.75.1
336808 WARNING Mar 04 14:24:50 java[5086]: 2021-03-04 14:24:50.758  INFO 5086 --- [           main] org.gotson.komga.ApplicationKt           : Starting ApplicationKt using Java 11.0.9.1 on ynh-appci-buster-amd64-stable-test with PID 5086 (/opt/yunohost/komga/app.jar started by komga in /opt/yunohost/komga)
336809 WARNING Mar 04 14:24:50 java[5086]: 2021-03-04 14:24:50.767  INFO 5086 --- [           main] org.gotson.komga.ApplicationKt           : No active profile set, falling back to default profiles: default
337354 INFO [##################+.] > Reloading NGINX web server...
338038 SUCCESS Restoration completed

 > Validating that the app can (or cannot) be accessed with its url...

Error: The HTTP code shows an error.
Warning: Test url: sub.domain.tld
Real url: https://sub.domain.tld/
HTTP code: 502
Page title: 
Page extract:
                               502 Bad Gateway
     __________________________________________________________________

                                    nginx
Error: The HTTP code shows an error.
Warning: Test url: sub.domain.tld/
Real url: https://sub.domain.tld/
HTTP code: 502
Page title: 
Page extract:
                               502 Bad Gateway
     __________________________________________________________________

                                    nginx
Warning: Expected to find an existing snapshot snap_subdirinstall but it doesn't exist yet .. will attempt to create it
Running: yunohost app install --force /app_folder -a domain=sub.domain.tld&path=/path&is_public=1&port=8080&admin=package_checker&
1118 INFO Installing komga...
1769 INFO [....................] > Validating installation parameters...
2679 INFO [++..................] > Storing installation settings...
3303 INFO [##..................] > Finding an available port...
3857 INFO [##+.................] > Installing dependencies...
23893 WARNING update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
26229 WARNING head: cannot open '/etc/ssl/certs/java/cacerts' for reading: No such file or directory
31986 INFO [###+++++++..........] > Setting up source files...
37852 INFO [##########+.........] > Configuring NGINX web server...
39997 INFO [###########+........] > Configuring system user...
40324 INFO [############+.......] > Configuring a systemd service...
42061 INFO [#############.......] > Configuring log rotation...
42271 INFO [#############+......] > Integrating service in YunoHost...
43093 INFO [##############+.....] > Starting a systemd service...
55270 WARNING Please wait, the service komga is starting..........
55395 INFO The service komga has correctly executed the action start.
55510 INFO [###############+....] > Configuring permissions...
57773 INFO [################+++.] > Reloading NGINX web server...
58933 SUCCESS Installation completed
(Creating snapshot snap_subdirinstall ...)

 > Backup of the application...

418  INFO Collecting files to be backed up for komga...
601  INFO Loading installation settings...
1277 INFO Declaring files to be backed up...
3462 INFO Backup script completed for komga. (YunoHost will then actually copy those files to the archive).
3843 INFO Creating a backup archive from the collected files...
4515 SUCCESS Backup created

 > Removing the app...

312  INFO Removing komga...
1042 INFO [+...................] > Loading installation settings...
3075 INFO [#+..................] > Removing komga service integration...
3401 INFO [##+++...............] > Stopping and removing the systemd service...
18567 INFO [#####+..............] > Removing dependencies...
26134 INFO [######+++++++.......] > Removing app main directory and database...
26359 INFO [#############++.....] > Removing NGINX web server configuration...
26910 INFO [###############++...] > Removing logrotate configuration...
27137 INFO [#################+..] > Removing the dedicated system user...
27619 SUCCESS komga removed

 > Restore after removing the application...

261  INFO Preparing archive for restoration...
834  INFO Restoring komga...
1713 INFO [....................] > Loading installation settings...
2878 INFO [+...................] > Validating restoration parameters...
3726 INFO [#++.................] > Restoring the app main directory...
3948 INFO [###+++++............] > Restoring the app database...
4185 INFO [########+...........] > Recreating the dedicated system user...
4520 INFO [#########+..........] > Reinstalling dependencies...
23188 WARNING update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
25527 WARNING head: cannot open '/etc/ssl/certs/java/cacerts' for reading: No such file or directory
31207 INFO [##########++++......] > Restoring the systemd configuration...
31925 INFO [##############++....] > Integrating service in YunoHost...
32551 INFO [################++..] > Starting a systemd service...
63977 WARNING Please wait, the service komga is starting.............................
63977 INFO The service komga has correctly executed the action start.
64207 INFO [##################+.] > Reloading NGINX web server...
64880 SUCCESS Restoration completed

 > Validating that the app can (or cannot) be accessed with its url...


 > Restore on a fresh YunoHost system...

335  INFO Preparing archive for restoration...
757  INFO Restoring komga...
1762 INFO [....................] > Loading installation settings...
3305 INFO [+...................] > Validating restoration parameters...
3651 INFO [#++.................] > Restoring the app main directory...
3875 INFO [###+++++............] > Restoring the app database...
4114 INFO [########+...........] > Recreating the dedicated system user...
4426 INFO [#########+..........] > Reinstalling dependencies...
33881 WARNING update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
36409 WARNING head: cannot open '/etc/ssl/certs/java/cacerts' for reading: No such file or directory
42298 INFO [##########++++......] > Restoring the systemd configuration...
42721 INFO [##############++....] > Integrating service in YunoHost...
43539 INFO [################++..] > Starting a systemd service...
72849 WARNING Please wait, the service komga is starting...........................
72966 INFO The service komga has correctly executed the action start.
73385 INFO [##################+.] > Reloading NGINX web server...
73813 INFO [####################] > Restoration completed for komga
73940 SUCCESS Restoration completed

 > Validating that the app can (or cannot) be accessed with its url...


--- FAIL ---

Working time for this test: 21 minutes, 51 seconds (14:32:36)

 ============================================
  [Test 7/8] Upgrade from the same version
 ============================================


 > Preliminary install...

(Reusing existing snapshot snap_rootinstall)

 > Upgrade...

314  INFO Now upgrading komga...
1833 INFO [....................] > Loading installation settings...
3275 INFO [+...................] > Ensuring downward compatibility...
3694 INFO [#+..................] > Backing up the app before upgrading (may take a while)...
8635 INFO [##+.................] > Stopping a systemd service...
8971 INFO [###++...............] > Upgrading source files...
13215 INFO [#####++++...........] > Upgrading NGINX web server configuration...
15471 INFO [#########...........] > Upgrading dependencies...
30959 INFO [#########++++.......] > Making sure dedicated system user exists...
31379 INFO [#############+......] > Upgrading systemd configuration...
33374 INFO [##############+.....] > Upgrading logrotate configuration...
33586 INFO [###############+....] > Integrating service in YunoHost...
34096 INFO [################+...] > Starting a systemd service...
538945 WARNING Please wait, the service komga is starting..................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
538946 WARNING The service komga didn't fully executed the action start before the timeout.
538947 WARNING Please find here an extract of the end of the log of the service komga:
539052 WARNING Mar 04 14:42:28 java[5658]:         at org.springframework.boot.autoconfigure.web.servlet.ServletWebServerFactoryCustomizer.customize(ServletWebServerFactoryCustomizer.java:39) ~[spring-boot-autoconfigure-2.4.1.jar!/:2.4.1]
539061 WARNING Mar 04 14:42:28 java[5658]:         at org.springframework.boot.web.server.WebServerFactoryCustomizerBeanPostProcessor.lambda$postProcessBeforeInitialization$0(WebServerFactoryCustomizerBeanPostProcessor.java:72) ~[spring-boot-2.4.1.jar!/:2.4.1]
539066 WARNING Mar 04 14:42:28 java[5658]:         at org.springframework.boot.util.LambdaSafe$Callbacks.lambda$null$0(LambdaSafe.java:287) ~[spring-boot-2.4.1.jar!/:2.4.1]
539069 WARNING Mar 04 14:42:28 java[5658]:         at org.springframework.boot.util.LambdaSafe$LambdaSafeCallback.invoke(LambdaSafe.java:159) ~[spring-boot-2.4.1.jar!/:2.4.1]
539075 WARNING Mar 04 14:42:28 java[5658]:         at org.springframework.boot.util.LambdaSafe$Callbacks.lambda$invoke$1(LambdaSafe.java:286) ~[spring-boot-2.4.1.jar!/:2.4.1]
539076 WARNING Mar 04 14:42:28 java[5658]:         at java.base/java.util.ArrayList.forEach(ArrayList.java:1541) ~[na:na]
539078 WARNING Mar 04 14:42:28 java[5658]:         at java.base/java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1085) ~[na:na]
539079 WARNING Mar 04 14:42:28 java[5658]:         at org.springframework.boot.util.LambdaSafe$Callbacks.invoke(LambdaSafe.java:286) ~[spring-boot-2.4.1.jar!/:2.4.1]
539080 WARNING Mar 04 14:42:28 java[5658]:         at org.springframework.boot.web.server.WebServerFactoryCustomizerBeanPostProcessor.postProcessBeforeInitialization(WebServerFactoryCustomizerBeanPostProcessor.java:72) ~[spring-boot-2.4.1.jar!/:2.4.1]
539081 WARNING Mar 04 14:42:28 java[5658]:         at org.springframework.boot.web.server.WebServerFactoryCustomizerBeanPostProcessor.postProcessBeforeInitialization(WebServerFactoryCustomizerBeanPostProcessor.java:58) ~[spring-boot-2.4.1.jar!/:2.4.1]
539082 WARNING Mar 04 14:42:28 java[5658]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyBeanPostProcessorsBeforeInitialization(AbstractAutowireCapableBeanFactory.java:429) ~[spring-beans-5.3.2.jar!/:5.3.2]
539084 WARNING Mar 04 14:42:28 java[5658]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1780) ~[spring-beans-5.3.2.jar!/:5.3.2]
539084 WARNING Mar 04 14:42:28 java[5658]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:609) ~[spring-beans-5.3.2.jar!/:5.3.2]
539085 WARNING Mar 04 14:42:28 java[5658]:         ... 25 common frames omitted
539086 WARNING Mar 04 14:42:28 systemd[1]: komga.service: Main process exited, code=exited, status=1/FAILURE
539095 WARNING Mar 04 14:42:28 systemd[1]: komga.service: Failed with result 'exit-code'.
539096 WARNING Mar 04 14:42:38 systemd[1]: komga.service: Service RestartSec=10s expired, scheduling restart.
539096 WARNING Mar 04 14:42:38 systemd[1]: komga.service: Scheduled restart job, restart counter is at 24.
539097 WARNING Mar 04 14:42:38 systemd[1]: Stopped Komga server.
539098 WARNING Mar 04 14:42:38 systemd[1]: Started Komga server.
539366 INFO [#################++.] > Reloading NGINX web server...
540199 INFO [####################] > Upgrade of komga completed
540942 SUCCESS komga upgraded
541122 SUCCESS Upgrade complete

 > Validating that the app can (or cannot) be accessed with its url...

Error: The HTTP code shows an error.
Warning: Test url: sub.domain.tld
Real url: https://sub.domain.tld/
HTTP code: 502
Page title: 
Page extract:
                               502 Bad Gateway
     __________________________________________________________________

                                    nginx
Error: The HTTP code shows an error.
Warning: Test url: sub.domain.tld/
Real url: https://sub.domain.tld/
HTTP code: 502
Page title: 
Page extract:
                               502 Bad Gateway
     __________________________________________________________________

                                    nginx

--- FAIL ---

Working time for this test: 10 minutes, 10 seconds (14:42:52)

 ============================================
  [Test 8/8] Change URL
 ============================================


 > Preliminary install...

(Reusing existing snapshot snap_rootinstall)

 > Changing the url from sub.domain.tld/ to sub.domain.tld/path...

1068 INFO [+...................] > Loading installation settings...
2393 INFO [#++.................] > Backing up the app before changing its URL (may take a while)...
7903 INFO [###++...............] > Stopping a systemd service...
8316 INFO [#####++.............] > Updating NGINX web server configuration...
10717 INFO [#######+++++++++....] > Starting a systemd service...
313712 WARNING Please wait, the service komga is starting..........................................................................................................................................................................................................................................................................................................
313717 WARNING The service komga didn't fully executed the action start before the timeout.
313718 WARNING Please find here an extract of the end of the log of the service komga:
313738 WARNING Mar 04 14:48:52 java[3528]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1780) ~[spring-beans-5.3.2.jar!/:5.3.2]
313755 WARNING Mar 04 14:48:52 java[3528]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:609) ~[spring-beans-5.3.2.jar!/:5.3.2]
313759 WARNING Mar 04 14:48:52 java[3528]:         ... 25 common frames omitted
313761 WARNING Mar 04 14:48:52 systemd[1]: komga.service: Main process exited, code=exited, status=1/FAILURE
313762 WARNING Mar 04 14:48:52 systemd[1]: komga.service: Failed with result 'exit-code'.
313763 WARNING Mar 04 14:49:02 systemd[1]: komga.service: Service RestartSec=10s expired, scheduling restart.
313764 WARNING Mar 04 14:49:02 systemd[1]: komga.service: Scheduled restart job, restart counter is at 14.
313765 WARNING Mar 04 14:49:02 systemd[1]: Stopped Komga server.
313767 WARNING Mar 04 14:49:02 systemd[1]: Started Komga server.
313768 WARNING Mar 04 14:49:05 java[3581]:  ____  __.
313769 WARNING Mar 04 14:49:05 java[3581]: |    |/ _|____   _____    _________
313775 WARNING Mar 04 14:49:05 java[3581]: |      < /  _ \ /     \  / ___\__  \
313777 WARNING Mar 04 14:49:05 java[3581]: |    |  (  <_> )  Y Y  \/ /_/  > __ \_
313778 WARNING Mar 04 14:49:05 java[3581]: |____|__ \____/|__|_|  /\___  (____  /
313781 WARNING Mar 04 14:49:05 java[3581]:         \/           \//_____/     \/
313791 WARNING Mar 04 14:49:05 java[3581]: Version: 0.75.1
313793 WARNING Mar 04 14:49:05 java[3581]: 2021-03-04 14:49:05.832  INFO 3581 --- [           main] org.gotson.komga.ApplicationKt           : Starting ApplicationKt using Java 11.0.9.1 on ynh-appci-buster-amd64-stable-test with PID 3581 (/opt/yunohost/komga/app.jar started by komga in /opt/yunohost/komga)
313800 WARNING Mar 04 14:49:05 java[3581]: 2021-03-04 14:49:05.846  INFO 3581 --- [           main] org.gotson.komga.ApplicationKt           : No active profile set, falling back to default profiles: default
313801 WARNING Mar 04 14:49:11 java[3581]: 2021-03-04 14:49:11.946  INFO 3581 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data JDBC repositories in DEFAULT mode.
313803 WARNING Mar 04 14:49:12 java[3581]: 2021-03-04 14:49:12.074  INFO 3581 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 116 ms. Found 0 JDBC repository interfaces.
314311 INFO [################++..] > Reloading NGINX web server...
314748 INFO [####################] > Change of URL completed for komga
314923 SUCCESS komga URL is now sub.domain.tld/path

 > Validating that the app can (or cannot) be accessed with its url...

Error: The HTTP code shows an error.
Warning: Test url: sub.domain.tld/path
Real url: https://sub.domain.tld/path/
HTTP code: 502
Page title: 
Page extract:
                               502 Bad Gateway
     __________________________________________________________________

                                    nginx
Error: The HTTP code shows an error.
Warning: Test url: sub.domain.tld/path/
Real url: https://sub.domain.tld/path/
HTTP code: 502
Page title: 
Page extract:
                               502 Bad Gateway
     __________________________________________________________________

                                    nginx

--- FAIL ---

Working time for this test: 6 minutes, 26 seconds (14:49:24)

 ============================================
 Tests summary
 ============================================


Package linter:                OK 
Install (root):               fail
Install (subdir):             fail
Install (private):             OK 
Install (multi):              fail
Backup/restore:               fail
Upgrade:                      fail
Change url:                   fail

Level results
=============
Level 1 (Installable in at least one scenario)    OK 
Level 2 (Installable in all scenarios)           
Level 3 (Can be upgraded)                        
Level 4 (Can be backup/restored)                 
Level 5 (No linter errors)                        ok 
Level 6 (App is in a community-operated git org)  ok 
Level 7 (Pass all tests + no linter warnings)    
Level 8 (Maintained and long-term good quality)  
Level 9 (Flagged high-quality in app catalog)    

Global level for this application: 1 (Installable in at least one scenario)

Global working time for all tests: 1 hour, 37 minutes, 55 seconds (14:49:29)
You can find the complete log of these tests in /home/CI_package_check/package_check/Complete.log
The complete log for this application was duplicated and is accessible at https://ci-apps-dev.yunohost.org/ci/logs/komga_amd64_stable_complete.log

-------------------------------------------

Application komga stays at level 1 on https://ci-apps-dev.yunohost.org/ci/job/584
Thu 04 Mar 2021 02:49:54 PM UTC - Test completed

</details>